### PR TITLE
Docker rename .hbs files to .handlebars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ COPY views views
 COPY package.json .
 COPY server.js .
 
+# Rename all .hbs files in views directory to .handlebars so Handlebars can read them.
+RUN for f in `find views -iname '*.hbs' -type f -print`; do mv "$f" ${f%.hbs}.handlebars; done
+
 RUN npm i -g npm@latest
 RUN npm install
 ENTRYPOINT ["npm","start"]


### PR DESCRIPTION
I have updated Duckerfile with a script that renames all `.hbs` files in `views` directory to `.handlebars`, so that Handlebars can read them without having to manually rename the files.