### PR TITLE
Hot fix of bot returns extra words alongside command keywords

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -210,7 +210,7 @@ export function choose(a, b) {
 }
 
 export function ignoreBlacklist(value, blacklist) {
-  const keyworkds = value?.split(' ');
+  const keyworkds = value?.split(' ') ?? [];
   for (const k of keyworkds) {
     if (blacklist?.includes(k))
       return "";

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -210,5 +210,10 @@ export function choose(a, b) {
 }
 
 export function ignoreBlacklist(value, blacklist) {
-  return blacklist?.includes(value) ? "" : value;
+  const keyworkds = value?.split(' ');
+  for (const k of keyworkds) {
+    if (blacklist?.includes(k))
+      return "";
+  }
+  return value;
 }


### PR DESCRIPTION
This PR handles the case of Rasa Bot returning command messages mixed with other words (such as "OPENSEARCH apollo" instead of "OPENSEARCH")