### PR TITLE
Fix Puppeteer issues

### DIFF
--- a/js/generate/convertHtmlToPdf.js
+++ b/js/generate/convertHtmlToPdf.js
@@ -1,7 +1,16 @@
 import * as puppeteer from 'puppeteer';
 
 export async function convertHtmlToPdf(html) {
-  const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-dev-shm-usage', '--enable-logging', '--v=1'], dumpio: true, });
+  const browser = await puppeteer.launch({
+    args: [
+      '--no-sandbox',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+      '--enable-logging',
+      '--v=1'
+    ],
+    dumpio: true,
+  });
   console.debug("convertHtmlToPdf: created browser")
   
   try {

--- a/js/generate/convertHtmlToPdf.js
+++ b/js/generate/convertHtmlToPdf.js
@@ -8,6 +8,8 @@ async function getBrowser() {
   browser = await puppeteer.launch({
     args: [
       '--no-sandbox',
+      // Necessary with newer versions of Puppeteer
+      // https://github.com/puppeteer/puppeteer/issues/12189
       '--disable-gpu',
       '--disable-dev-shm-usage',
       '--enable-logging',

--- a/js/generate/convertHtmlToPdf.js
+++ b/js/generate/convertHtmlToPdf.js
@@ -1,7 +1,11 @@
 import * as puppeteer from 'puppeteer';
 
-export async function convertHtmlToPdf(html) {
-  const browser = await puppeteer.launch({
+let browser;
+
+async function getBrowser() {
+  if (browser) return browser;
+
+  browser = await puppeteer.launch({
     args: [
       '--no-sandbox',
       '--disable-gpu',
@@ -11,8 +15,14 @@ export async function convertHtmlToPdf(html) {
     ],
     dumpio: true,
   });
-  console.debug("convertHtmlToPdf: created browser")
-  
+  console.debug("convertHtmlToPdf: created browser");
+
+  return browser;
+}
+
+export async function convertHtmlToPdf(html) {
+  const browser = await getBrowser();
+
   try {
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: "load", timeout: 0 });
@@ -31,13 +41,12 @@ export async function convertHtmlToPdf(html) {
     // But this may be bugged in Puppeteer: https://github.com/puppeteer/puppeteer/issues/7922
     await page.close();
     console.debug("convertHtmlToPdf: closed page")
-    await browser.close();
-    console.debug("convertHtmlToPdf: closed browser")
 
     return base64;
   } catch (error) {
     console.error("convertHtmlToPdf: error", error);
     await browser.close();
+    console.debug("convertHtmlToPdf: closed browser on error")
     throw error;
   }
 }

--- a/js/generate/convertHtmlToPdf.js
+++ b/js/generate/convertHtmlToPdf.js
@@ -37,8 +37,6 @@ export async function convertHtmlToPdf(html) {
     const base64 = Buffer.from(uintArray).toString("base64");
     console.debug("convertHtmlToPdf: created pdf")
 
-    // Closing the page explicitly should not be needed normally
-    // But this may be bugged in Puppeteer: https://github.com/puppeteer/puppeteer/issues/7922
     await page.close();
     console.debug("convertHtmlToPdf: closed page")
 


### PR DESCRIPTION
Related tasks:

- https://github.com/buerokratt/DataMapper/issues/126
- https://github.com/buerokratt/Buerokratt-Chatbot/issues/959

Notes:

- `--disable-gpu` should fix the PDF generation.
- Using singleton pattern for the Puppeteer's `browser`: should prevent spawning multiple Chromium instances even if there is an error or there are multiple simultaneous requests to generate PDFs. This also makes PDF generation ~280ms faster.
- Will leave debug logging for now — if all is good, will remove later.