### PR TITLE
Implement support for using custom CA certificates for SMAX requests

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
-import * as path from 'path';
 import https from 'https';
+import * as path from 'path';
 
 import axios from 'axios';
 import bodyParser from 'body-parser';

--- a/server.ts
+++ b/server.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import * as path from 'path';
+import https from 'https';
 
 import axios from 'axios';
 import bodyParser from 'body-parser';
@@ -338,6 +339,13 @@ app.post(
         { Login, Password },
         {
           headers: { 'Content-Type': 'application/json' },
+          ...(process.env.SMAX_CA_CERTIFICATE
+            ? {
+                httpsAgent: new https.Agent({
+                  ca: process.env.SMAX_CA_CERTIFICATE.replace(/\\n/g, '\n'),
+                }),
+              }
+            : {}),
         },
       );
       res.json({ token: data });


### PR DESCRIPTION
Implement support for using custom CA certificates for SMAX requests.
This PR is related to issue https://github.com/buerokratt/Buerokratt-Chatbot/issues/2051